### PR TITLE
chore(build): updates the dependent from libcstor to cstor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,5 +67,5 @@ script:
       fi;
       REL_BRANCH=$(echo $(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x$REL_SUFFIX) ;
       ./buildscripts/git-release "${REPO_ORG}/jiva" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
-      ./buildscripts/git-release "${REPO_ORG}/libcstor" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
+      ./buildscripts/git-release "${REPO_ORG}/cstor" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
     fi


### PR DESCRIPTION
This PR updates the downstream dependent repo
from libcstor to cstor. Since the build process has
been moved from cstor to libcstor. For more info 
refer [#70](https://github.com/openebs/libcstor/pull/70) and [#319](https://github.com/openebs/cstor/pull/319).


Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>