### PR TITLE
chore(build): add support to push to multiple registries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set tag
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
+
+      - name: Set CI Tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
           CI_TAG=${BRANCH#v}-ci
@@ -30,7 +36,28 @@ jobs:
             CI_TAG="ci"
           fi
           echo "TAG=${CI_TAG}" >> $GITHUB_ENV
-          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/linux-utils
+            quay.io/${{ env.IMAGE_ORG }}/linux-utils
+          tag-latest: false
+          tag-custom-only: true
+          tag-custom: |
+            ${{ env.TAG }}
+
+      - name: Print Tags
+        run: |
+          echo "${{ steps.docker_meta.outputs.tags }}"
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
@@ -49,13 +76,28 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        run: |
-          make buildx.image
-          make buildx.push
+        uses: docker/build-push-action@v2
+        with:
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/linux-utils
+            DBUILD_SITE_URL=https://openebs.io
         
   trivy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: ['linux-utils']
     steps:
       - name: Checkout code
@@ -64,7 +106,9 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: openebs/linux-utils:${{ env.TAG }}
+          # the tag will be always ci since only master branch is present
+          # in this repository
+          image-ref: 'openebs/linux-utils:ci'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,9 +40,13 @@ jobs:
           version: v0.5.1
 
       - name: Build Image
-        env:
-          IMG_RESULT: load
-        run: make buildx.image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./Dockerfile
+          push: false
+          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le
+          tags: |
+            openebs/linux-utils:ci
         
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           file: ./Dockerfile
           push: false
+          load: true
           platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le
           tags: |
             openebs/linux-utils:ci

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,7 +45,7 @@ jobs:
           file: ./Dockerfile
           push: false
           load: true
-          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le
+          platforms: linux/amd64
           tags: |
             openebs/linux-utils:ci
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,38 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Set Tag
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
+
+      - name: Set Release Tag
         run: |
           TAG="${GITHUB_REF#refs/*/v}"
-          echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/linux-utils
+            quay.io/${{ env.IMAGE_ORG }}/linux-utils
+          tag-latest: true
+          tag-semver: |
+            {{version}}
+
+      - name: Print Tags
+        run: |
+          echo "${{ steps.docker_meta.outputs.tags }}"
+          echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
@@ -48,22 +75,37 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        run: |
-          make buildx.image
-          make buildx.push
+        uses: docker/build-push-action@v2
+        with:
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/linux-utils
+            DBUILD_SITE_URL=https://openebs.io
+            RELEASE_TAG=${RELEASE_TAG}
 
   trivy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: ['linux-utils']
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
         
-      - name: Set Tag
+      - name: Set Release Tag
         run: |
           TAG="${GITHUB_REF#refs/*/v}"
-          echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
         
       - name: Run Trivy vulnerability scanner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.0
+FROM alpine:3.12.4
 RUN apk add --no-cache util-linux
 
 ARG DBUILD_DATE


### PR DESCRIPTION
- add support to push images to multiple registries
- use ubuntu-latest in the workflow
- use docker build-push action instead of scripts
- update alpine version to `3.12.4` to mitigate some security vulnerabilities with HIGH severity

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>