### PR TITLE
chore(workflow): remove libcstor from downstream tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,6 @@ jobs:
           repo: |
             jiva
             cstor
-            libcstor
             dynamic-localpv-provisioner
             m-exporter
           # GR_TOKEN secret is the access token to perform github releases


### PR DESCRIPTION
libcstor will be tagged from cstor repo

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>