### PR TITLE
fix(workflow): remove m-exporter from release hierarchy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,5 @@ jobs:
             cstor
             libcstor
             dynamic-localpv-provisioner
-            m-exporter
           # GR_TOKEN secret is the access token to perform github releases
           github-token: ${{ secrets.GR_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.6
+FROM alpine:3.12.7
 RUN apk add --no-cache util-linux
 
 ARG DBUILD_DATE


### PR DESCRIPTION
move m-exporter as dependent of libcstor repository in release tagging

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>