### PR TITLE
chore(repo): rename branch master to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF##*/}"
           CI_TAG=${BRANCH#v}-ci
-          if [ ${BRANCH} = "master" ]; then
+          if [ ${BRANCH} = "main" ]; then
             CI_TAG="ci"
           fi
           echo "TAG=${CI_TAG}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          # the tag will be always ci since only master branch is present
+          # the tag will be always ci since only main branch is present
           # in this repository
           image-ref: 'openebs/linux-utils:ci'
           format: 'table'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,8 +17,7 @@ name: ci
 on:
   pull_request:
     branches:
-      # on pull requests to master and release branches
-      - master
+      # on pull requests to main and release branches
       - main
       - 'v*'
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,6 +19,7 @@ on:
     branches:
       # on pull requests to master and release branches
       - master
+      - main
       - 'v*'
 
 jobs:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 ## Community Code of Conduct
 
-This project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+This project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/HEAD/code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ OpenEBS is an Apache 2.0 Licensed project and all your commits should be signed 
 * Find an issue to work on or create a new issue. The issues are maintained at [openebs/openebs](https://github.com/openebs/openebs/issues). You can pick up from a list of [good-first-issues](https://github.com/openebs/openebs/labels/good%20first%20issue).
 * Claim your issue by commenting your intent to work on it to avoid duplication of efforts.
 * Fork the repository on GitHub.
-* Create a branch from where you want to base your work (usually `main` or `develop`).
+* Create a branch from where you want to base your work (usually `main`).
 * Make your changes. 
 * Commit your changes by making sure the commit messages convey the need and notes about the commit.
 * Push your changes to the branch in your fork of the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ OpenEBS uses the standard GitHub pull requests process to review and accept cont
 
 * If you have a trivial fix or improvement, go ahead and create a pull request, addressing (with `@...`) the maintainer of this repository (see [MAINTAINERS.md](MAINTAINERS.md)) in the description of the pull request.
 
-* If you would like to work on something more involved, please connect with the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/master/community).
+* If you would like to work on something more involved, please connect with the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/HEAD/community).
 
 ## Steps to Contribute
 
@@ -13,7 +13,7 @@ OpenEBS is an Apache 2.0 Licensed project and all your commits should be signed 
 * Find an issue to work on or create a new issue. The issues are maintained at [openebs/openebs](https://github.com/openebs/openebs/issues). You can pick up from a list of [good-first-issues](https://github.com/openebs/openebs/labels/good%20first%20issue).
 * Claim your issue by commenting your intent to work on it to avoid duplication of efforts.
 * Fork the repository on GitHub.
-* Create a branch from where you want to base your work (usually master).
+* Create a branch from where you want to base your work (usually `main` or `develop`).
 * Make your changes. 
 * Commit your changes by making sure the commit messages convey the need and notes about the commit.
 * Push your changes to the branch in your fork of the repository.
@@ -21,18 +21,18 @@ OpenEBS is an Apache 2.0 Licensed project and all your commits should be signed 
 
 ## Pull Request Checklist
 
-* Rebase to the current master branch before submitting your pull request.
+* Rebase to the current main branch before submitting your pull request.
 * Commits should be as small as possible. Each commit should follow the checklist below:
   - For code changes, add tests relevant to the fixed bug or new feature.
   - Pass the compile and tests - includes spell checks, formatting, etc.
   - Commit header (first line) should convey what changed.
   - Commit body should include details such as why the changes are required and how the proposed changes.
   - DCO Signed.
-* If your PR is not getting reviewed or you need a specific person to review it, please reach out to the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/master/community).
+* If your PR is not getting reviewed or you need a specific person to review it, please reach out to the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/HEAD/community).
 
 ## Sign your work
 
-We use the Developer Certificate of Origin (DCO) as an additional safeguard for the OpenEBS project. This is a well established and widely used mechanism to assure that contributors have confirmed their right to license their contribution under the project's license. Please read [dcofile](https://github.com/openebs/openebs/blob/master/contribute/developer-certificate-of-origin). If you can certify it, then just add a line to every git commit message:
+We use the Developer Certificate of Origin (DCO) as an additional safeguard for the OpenEBS project. This is a well established and widely used mechanism to assure that contributors have confirmed their right to license their contribution under the project's license. Please read [dcofile](https://github.com/openebs/openebs/blob/HEAD/contribute/developer-certificate-of-origin). If you can certify it, then just add a line to every git commit message:
 
 ```
   Signed-off-by: Random J Developer <random@developer.example.org>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.1
+FROM alpine:3.14.2
 RUN apk add --no-cache util-linux xfsprogs xfsprogs-extra
 
 ARG DBUILD_DATE

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,1 +1,1 @@
-This is a OpenEBS sub project and abides by the [OpenEBS Project Governance](https://github.com/openebs/openebs/blob/master/GOVERNANCE.md).
+This is a OpenEBS sub project and abides by the [OpenEBS Project Governance](https://github.com/openebs/openebs/blob/HEAD/GOVERNANCE.md).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
 This is a OpenEBS sub project and abides by the 
-[OpenEBS Release Process](https://github.com/openebs/openebs/blob/master/RELEASE.md).
+[OpenEBS Release Process](https://github.com/openebs/openebs/blob/HEAD/RELEASE.md).
 
 `linux-utils` is the first repository to be tagged as part of the release, which will 
 in turn trigger the down stream repository releases.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,2 +1,2 @@
 This is a OpenEBS sub project and abides by the 
-[OpenEBS Security Release Process](https://github.com/openebs/openebs/blob/master/SECURITY.md).
+[OpenEBS Security Release Process](https://github.com/openebs/openebs/blob/HEAD/SECURITY.md).


### PR DESCRIPTION
- As part of inclusive naming, work towards renaming branches
  with name master to main or develop
- Updated the referece to base apline to latest

Signed-off-by: kmova <kiran.mova@mayadata.io>