### PR TITLE
fix(downward-tagging): remove openebs/cstor from downward-tagging release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,6 @@ jobs:
           body: 'Release created from linux-utils'
           repo: |
             jiva
-            cstor
             libcstor
             dynamic-localpv-provisioner
           # GR_TOKEN secret is the access token to perform github releases


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>

openebs/cstor has been moved to [mayadata-io/cstor](https://github.com/mayadata-io/cstor) and does not need to be included in the downward tagging release workflow.