### PR TITLE
fix(base-image): upgrade alpine version to 3.14.6 to mitigate CVE-2022-28391

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,8 @@
+# This vulnerability has been fixed in alpine 3.14.6.
+# We have upgraded to 3.14.6, but the aquasecurity/trivy-action
+# v0.2.4 keeps failing because the database is not up to date.
+# https://github.com/aquasecurity/trivy/issues/1988
+CVE-2022-28391
+
+# The zgrep utility is not installed in the linux-utils image
+CVE-2022-1271

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.5
+FROM alpine:3.14.6
 RUN apk add --no-cache util-linux xfsprogs xfsprogs-extra lvm2 device-mapper
 
 ARG DBUILD_DATE


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

Upgrading to Alpine release 3.14.6 to mitigate CVE-2022-28391.