### PR TITLE
fix(Dockerfile): upgrade base image alpine version to 3.14.8 for CVE-2022-37434

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.14.6
+FROM alpine:3.14.8
+
 RUN apk add --no-cache util-linux xfsprogs xfsprogs-extra lvm2 device-mapper e2fsprogs-extra quota-tools
 
 ARG DBUILD_DATE


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>

This is required because trivy validation fails due to CVE-2022-37434.