### PR TITLE
chore: use `alpine:3.21.0` as base image

### DIFF
--- a/dockerfiles/alpine-bash/Dockerfile
+++ b/dockerfiles/alpine-bash/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.1
+FROM alpine:3.21.0
 
 RUN apk add --no-cache bash
 

--- a/dockerfiles/alpine-sh/Dockerfile
+++ b/dockerfiles/alpine-sh/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.1
+FROM alpine:3.21.0
 
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL="https://github.com/openebs/linux-utils"

--- a/dockerfiles/linux-utils/Dockerfile
+++ b/dockerfiles/linux-utils/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.1
+FROM alpine:3.21.0
 
 RUN apk add --no-cache util-linux xfsprogs xfsprogs-extra lvm2 device-mapper e2fsprogs-extra quota-tools
 


### PR DESCRIPTION
Main goal of this commit is to remediate CVEs in the base image https://hub.docker.com/layers/library/alpine/3.20.1/images/sha256-dabf91b69c191a1a0a1628fd6bdd029c0c4018041c7f052870bb13c5a222ae76?context=explore